### PR TITLE
Implement a specialized data client to handle has  filters for country model

### DIFF
--- a/lib/app/bloc/app_bloc.dart
+++ b/lib/app/bloc/app_bloc.dart
@@ -58,8 +58,8 @@ class AppBloc extends Bloc<AppEvent, AppState> {
            // Initialize status and user based on initialUser
            status: initialUser != null
                ? (initialUser.appRole == AppUserRole.standardUser
-                   ? AppStatus.authenticated
-                   : AppStatus.anonymous)
+                     ? AppStatus.authenticated
+                     : AppStatus.anonymous)
                : AppStatus.unauthenticated,
            user: initialUser,
          ),

--- a/lib/authentication/view/request_code_page.dart
+++ b/lib/authentication/view/request_code_page.dart
@@ -5,8 +5,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_news_app_mobile_client_full_source_code/app/bloc/app_bloc.dart';
-import 'package:flutter_news_app_mobile_client_full_source_code/app/config/config.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/authentication/bloc/authentication_bloc.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/l10n/l10n.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/router/routes.dart';

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -18,6 +18,7 @@ import 'package:flutter_news_app_mobile_client_full_source_code/app/config/confi
     as app_config;
 import 'package:flutter_news_app_mobile_client_full_source_code/app/services/demo_data_migration_service.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/bloc_observer.dart';
+import 'package:flutter_news_app_mobile_client_full_source_code/shared/data/clients/country_inmemory_client.dart';
 import 'package:http_client/http_client.dart';
 import 'package:kv_storage_shared_preferences/kv_storage_shared_preferences.dart';
 import 'package:logging/logging.dart';
@@ -105,6 +106,13 @@ Future<Widget> bootstrap(
       getId: (i) => i.id,
       initialData: countriesFixturesData,
       logger: logger,
+    );
+    // Wrap the generic DataInMemory<Country> with CountryInMemoryClient
+    // to add specialized filtering like 'hasActiveSources' and 'hasActiveHeadlines'.
+    countriesClient = CountryInMemoryClient(
+      decoratedClient: countriesClient,
+      allSources: sourcesFixturesData,
+      allHeadlines: headlinesFixturesData,
     );
     sourcesClient = DataInMemory<Source>(
       toJson: (i) => i.toJson(),

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -107,13 +107,35 @@ Future<Widget> bootstrap(
       initialData: countriesFixturesData,
       logger: logger,
     );
-    // Wrap the generic DataInMemory<Country> with CountryInMemoryClient
-    // to add specialized filtering like 'hasActiveSources' and 'hasActiveHeadlines'.
+    
+    // Wrap the generic DataInMemory<Country> with CountryInMemoryClient.
+    // This decorator adds specialized filtering for 'hasActiveSources' and
+    // 'hasActiveHeadlines' which are specific to the application's needs
+    // in the demo environment.
+    //
+    // Rationale:
+    // 1.  **Demo Environment Specific:** This client-side decorator is only
+    //     applied in the `demo` environment. In this mode, data is served
+    //     from static in-memory fixtures, and this decorator enables complex
+    //     filtering on that local data.
+    // 2.  **API Environments (Development/Production):** For `development`
+    //     and `production` environments, the `countriesClient` is an instance
+    //     of `DataApi<Country>`. In these environments, the backend API
+    //     (which includes services like `CountryQueryService`) is responsible
+    //     for handling all advanced filtering and aggregation logic. Therefore,
+    //     this client-side decorator is not needed.
+    // 3.  **Preserving Genericity:** The core `DataInMemory<T>` client (from
+    //     the `data-inmemory` package) is designed to be generic and reusable
+    //     across various projects. Modifying it directly with application-specific
+    //     logic would violate the Single Responsibility Principle and reduce
+    //     its reusability. The Decorator Pattern allows us to extend its
+    //     functionality for `Country` models without altering the generic base.
     countriesClient = CountryInMemoryClient(
       decoratedClient: countriesClient,
       allSources: sourcesFixturesData,
       allHeadlines: headlinesFixturesData,
     );
+    //
     sourcesClient = DataInMemory<Source>(
       toJson: (i) => i.toJson(),
       getId: (i) => i.id,

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -107,7 +107,7 @@ Future<Widget> bootstrap(
       initialData: countriesFixturesData,
       logger: logger,
     );
-    
+
     // Wrap the generic DataInMemory<Country> with CountryInMemoryClient.
     // This decorator adds specialized filtering for 'hasActiveSources' and
     // 'hasActiveHeadlines' which are specific to the application's needs

--- a/lib/shared/data/clients/country_inmemory_client.dart
+++ b/lib/shared/data/clients/country_inmemory_client.dart
@@ -1,0 +1,134 @@
+import 'package:core/core.dart';
+import 'package:data_client/data_client.dart';
+
+/// {@template country_inmemory_client}
+/// A specialized in-memory data client for [Country] models that extends
+/// the functionality of a generic [DataClient<Country>] by adding custom
+/// filtering logic for `hasActiveSources` and `hasActiveHeadlines` filters.
+///
+/// This client acts as a decorator, wrapping an existing [DataClient<Country>]
+/// (typically [DataInMemory<Country>]) and intercepting `readAll` calls
+/// to apply application-specific filtering using static fixture data.
+/// All other [DataClient] methods are delegated directly to the wrapped client.
+/// {@endtemplate}
+class CountryInMemoryClient implements DataClient<Country> {
+  /// {@macro country_inmemory_client}
+  ///
+  /// Requires a [decoratedClient] to which standard data operations will be
+  /// delegated. Also requires [allSources] and [allHeadlines] (typically
+  /// static fixture data from the `core` package) to perform custom filtering.
+  const CountryInMemoryClient({
+    required DataClient<Country> decoratedClient,
+    required List<Source> allSources,
+    required List<Headline> allHeadlines,
+  })  : _decoratedClient = decoratedClient,
+        _allSources = allSources,
+        _allHeadlines = allHeadlines;
+
+  final DataClient<Country> _decoratedClient;
+  final List<Source> _allSources;
+  final List<Headline> _allHeadlines;
+
+  @override
+  Future<SuccessApiResponse<List<Map<String, dynamic>>>> aggregate({
+    required List<Map<String, dynamic>> pipeline,
+    String? userId,
+  }) {
+    return _decoratedClient.aggregate(pipeline: pipeline, userId: userId);
+  }
+
+  @override
+  Future<SuccessApiResponse<int>> count({
+    String? userId,
+    Map<String, dynamic>? filter,
+  }) {
+    return _decoratedClient.count(userId: userId, filter: filter);
+  }
+
+  @override
+  Future<SuccessApiResponse<Country>> create({
+    required Country item,
+    String? userId,
+  }) {
+    return _decoratedClient.create(item: item, userId: userId);
+  }
+
+  @override
+  Future<void> delete({required String id, String? userId}) {
+    return _decoratedClient.delete(id: id, userId: userId);
+  }
+
+  @override
+  Future<SuccessApiResponse<Country>> read({
+    required String id,
+    String? userId,
+  }) {
+    return _decoratedClient.read(id: id, userId: userId);
+  }
+
+  @override
+  Future<SuccessApiResponse<PaginatedResponse<Country>>> readAll({
+    String? userId,
+    Map<String, dynamic>? filter,
+    PaginationOptions? pagination,
+    List<SortOption>? sort,
+  }) async {
+    // First, get the initial list of countries from the decorated client.
+    // This handles generic filters, sorting, and pagination.
+    final response = await _decoratedClient.readAll(
+      userId: userId,
+      filter: filter,
+      pagination: pagination,
+      sort: sort,
+    );
+
+    var filteredCountries = response.data.items;
+
+    // Apply custom filters if present
+    final hasActiveSources = filter?['hasActiveSources'] == true;
+    final hasActiveHeadlines = filter?['hasActiveHeadlines'] == true;
+
+    if (hasActiveSources) {
+      final countriesWithActiveSources = _allSources
+          .where((source) => source.status == ContentStatus.active)
+          .map((source) => source.headquarters.id)
+          .toSet();
+
+      filteredCountries = filteredCountries
+          .where(
+            (country) => countriesWithActiveSources.contains(country.id),
+          )
+          .toList();
+    }
+
+    if (hasActiveHeadlines) {
+      final countriesWithActiveHeadlines = _allHeadlines
+          .where((headline) => headline.status == ContentStatus.active)
+          .map((headline) => headline.eventCountry.id)
+          .toSet();
+
+      filteredCountries = filteredCountries
+          .where(
+            (country) => countriesWithActiveHeadlines.contains(country.id),
+          )
+          .toList();
+    }
+
+    // Return a new PaginatedResponse with the potentially further filtered items.
+    // The cursor and hasMore logic from the original response are preserved,
+    // but the items list is updated.
+    return SuccessApiResponse(
+      data: response.data.copyWith(items: filteredCountries),
+      metadata: response.metadata,
+    );
+  }
+
+  @override
+  Future<SuccessApiResponse<Country>> update({
+    required String id,
+    required Country item,
+    String? userId,
+  }) {
+    return _decoratedClient.update(id: id, item: item, userId: userId);
+  }
+}


### PR DESCRIPTION
## Status

**READY**

## Description

This pull request introduces a new specialized data client, CountryInMemoryClient, designed to enhance the filtering capabilities for Country models within the mobile client's demo environment. The primary purpose is to enable filtering of countries based on the presence of active sources or active headlines, without altering the existing generic DataInMemory<T> client. This is achieved by implementing a decorator pattern, allowing the new client to wrap and extend the functionality of the base country data client.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore