### PR TITLE
Feat/app version enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.0
+
+-   **Feature:** Implemented app version enforcement based on remote configuration, including a dedicated `UpdateRequiredPage` to guide users to update.
+-   **Enhancement:** Integrated `package_info_plus` and `pub_semver` for accurate version retrieval and comparison across platforms (Android, iOS, Web).
+
 ## 1.0.1
 
 -   **Version Control:** Transitioned from date-based versioning to semantic versioning. This release marks the first version following the semantic versioning standard.

--- a/lib/app/bloc/app_bloc.dart
+++ b/lib/app/bloc/app_bloc.dart
@@ -269,7 +269,8 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     add(
       AppVersionCheckRequested(
         remoteConfig: state.remoteConfig!,
-        isBackgroundCheck: false, // Not a background check during startup
+        // Not a background check during startup
+        isBackgroundCheck: false, 
       ),
     );
 

--- a/lib/app/bloc/app_bloc.dart
+++ b/lib/app/bloc/app_bloc.dart
@@ -270,7 +270,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
       AppVersionCheckRequested(
         remoteConfig: state.remoteConfig!,
         // Not a background check during startup
-        isBackgroundCheck: false, 
+        isBackgroundCheck: false,
       ),
     );
 
@@ -638,7 +638,12 @@ class AppBloc extends Bloc<AppEvent, AppState> {
           '[AppBloc] App version ($currentVersion) is older than '
           'required ($latestRequiredVersion). Transitioning to updateRequired state.',
         );
-        emit(state.copyWith(status: AppLifeCycleStatus.updateRequired));
+        emit(
+          state.copyWith(
+            status: AppLifeCycleStatus.updateRequired,
+            currentAppVersion: currentAppVersionString,
+          ),
+        );
       } else {
         _logger.info(
           '[AppBloc] App version ($currentVersion) is up to date '
@@ -650,10 +655,16 @@ class AppBloc extends Bloc<AppEvent, AppState> {
           final finalStatus = state.user!.appRole == AppUserRole.standardUser
               ? AppLifeCycleStatus.authenticated
               : AppLifeCycleStatus.anonymous;
-          emit(state.copyWith(status: finalStatus));
+          emit(
+            state.copyWith(
+              status: finalStatus,
+              currentAppVersion: currentAppVersionString,
+            ),
+          );
+        } else {
+          emit(state.copyWith(currentAppVersion: currentAppVersionString));
         }
       }
-      emit(state.copyWith(currentAppVersion: currentAppVersionString));
     } on FormatException catch (e, s) {
       _logger.severe(
         '[AppBloc] Failed to parse app version string: $currentAppVersionString '

--- a/lib/app/bloc/app_bloc.dart
+++ b/lib/app/bloc/app_bloc.dart
@@ -633,18 +633,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
         remoteConfig.appStatus.latestAppVersion,
       );
 
-      if (currentVersion < latestRequiredVersion) {
-        _logger.info(
-          '[AppBloc] App version ($currentVersion) is older than '
-          'required ($latestRequiredVersion). Transitioning to updateRequired state.',
-        );
-        emit(
-          state.copyWith(
-            status: AppLifeCycleStatus.updateRequired,
-            currentAppVersion: currentAppVersionString,
-          ),
-        );
-      } else {
+      if (currentVersion >= latestRequiredVersion) {
         _logger.info(
           '[AppBloc] App version ($currentVersion) is up to date '
           'or newer than required ($latestRequiredVersion).',
@@ -664,6 +653,17 @@ class AppBloc extends Bloc<AppEvent, AppState> {
         } else {
           emit(state.copyWith(currentAppVersion: currentAppVersionString));
         }
+      } else {
+        _logger.info(
+          '[AppBloc] App version ($currentVersion) is older than '
+          'required ($latestRequiredVersion). Transitioning to updateRequired state.',
+        );
+        emit(
+          state.copyWith(
+            status: AppLifeCycleStatus.updateRequired,
+            currentAppVersion: currentAppVersionString,
+          ),
+        );
       }
     } on FormatException catch (e, s) {
       _logger.severe(

--- a/lib/app/bloc/app_event.dart
+++ b/lib/app/bloc/app_event.dart
@@ -89,6 +89,28 @@ class AppPeriodicConfigFetchRequested extends AppEvent {
   List<Object> get props => [isBackgroundCheck];
 }
 
+/// Dispatched to request a check of the application's version against
+/// the remote configuration.
+///
+/// This event is used to determine if a mandatory update is required.
+class AppVersionCheckRequested extends AppEvent {
+  const AppVersionCheckRequested({
+    required this.remoteConfig,
+    this.isBackgroundCheck = true,
+  });
+
+  /// The latest remote configuration.
+  final RemoteConfig remoteConfig;
+
+  /// Whether this check is a silent background check.
+  ///
+  /// If `true`, the BLoC will not enter a visible loading state.
+  final bool isBackgroundCheck;
+
+  @override
+  List<Object> get props => [remoteConfig, isBackgroundCheck];
+}
+
 /// Dispatched when the user logs out.
 ///
 /// This event triggers the sign-out process, clearing authentication tokens

--- a/lib/app/bloc/app_state.dart
+++ b/lib/app/bloc/app_state.dart
@@ -48,6 +48,7 @@ class AppState extends Equatable {
     this.userContentPreferences,
     this.settings,
     this.selectedBottomNavigationIndex = 0,
+    this.currentAppVersion,
   });
 
   /// The current status of the application, indicating its lifecycle stage.
@@ -83,6 +84,14 @@ class AppState extends Equatable {
 
   /// The current application environment (e.g., demo, development, production).
   final local_config.AppEnvironment environment;
+
+  /// The current version of the application, fetched from `package_info_plus`.
+  /// This is used for version enforcement.
+  final String? currentAppVersion;
+
+  /// The latest required app version from the remote configuration.
+  /// Returns `null` if remote config is not available.
+  String? get latestAppVersion => remoteConfig?.appStatus.latestAppVersion;
 
   /// The current theme mode (light, dark, or system), derived from [settings].
   /// Defaults to [ThemeMode.system] if [settings] are not yet loaded.
@@ -152,6 +161,7 @@ class AppState extends Equatable {
     userContentPreferences,
     selectedBottomNavigationIndex,
     environment,
+    currentAppVersion,
   ];
 
   /// Creates a copy of this [AppState] with the given fields replaced with
@@ -167,6 +177,7 @@ class AppState extends Equatable {
     UserContentPreferences? userContentPreferences,
     int? selectedBottomNavigationIndex,
     local_config.AppEnvironment? environment,
+    String? currentAppVersion,
   }) {
     return AppState(
       status: status ?? this.status,
@@ -182,6 +193,7 @@ class AppState extends Equatable {
       selectedBottomNavigationIndex:
           selectedBottomNavigationIndex ?? this.selectedBottomNavigationIndex,
       environment: environment ?? this.environment,
+      currentAppVersion: currentAppVersion ?? this.currentAppVersion,
     );
   }
 }

--- a/lib/app/services/package_info_service.dart
+++ b/lib/app/services/package_info_service.dart
@@ -1,0 +1,49 @@
+import 'package:logging/logging.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// {@template package_info_service}
+/// An abstract service for retrieving application package information.
+///
+/// This interface allows for mocking and provides a clean way to access
+/// platform-specific app details like version, build number, etc.
+/// {@endtemplate}
+abstract class PackageInfoService {
+  /// {@macro package_info_service}
+  const PackageInfoService();
+
+  /// Retrieves the application's version string (e.g., "1.0.0").
+  ///
+  /// Returns `null` if the version cannot be determined (e.g., on unsupported
+  /// platforms or during an error).
+  Future<String?> getAppVersion();
+}
+
+/// {@template package_info_service_impl}
+/// A concrete implementation of [PackageInfoService] using `package_info_plus`.
+/// {@endtemplate}
+class PackageInfoServiceImpl implements PackageInfoService {
+  /// {@macro package_info_service_impl}
+  PackageInfoServiceImpl({Logger? logger})
+    : _logger = logger ?? Logger('PackageInfoServiceImpl');
+
+  final Logger _logger;
+
+  @override
+  Future<String?> getAppVersion() async {
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      _logger.info(
+        'Successfully fetched package info. Version: ${packageInfo.version}',
+      );
+      return packageInfo.version;
+    } catch (e, s) {
+      _logger.warning(
+        'Failed to get app version from platform. '
+        'This might be expected on some platforms (e.g., web in certain contexts).',
+        e,
+        s,
+      );
+      return null;
+    }
+  }
+}

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -11,6 +11,7 @@ import 'package:flutter_news_app_mobile_client_full_source_code/app/config/app_e
 import 'package:flutter_news_app_mobile_client_full_source_code/app/services/app_status_service.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/app/services/demo_data_initializer_service.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/app/services/demo_data_migration_service.dart';
+import 'package:flutter_news_app_mobile_client_full_source_code/app/services/package_info_service.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/authentication/bloc/authentication_bloc.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/l10n/app_localizations.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/router/router.dart';
@@ -48,6 +49,7 @@ class App extends StatelessWidget {
     required InlineAdCacheService inlineAdCacheService,
     required RemoteConfig? initialRemoteConfig,
     required HttpException? initialRemoteConfigError,
+    required PackageInfoService packageInfoService,
     super.key,
     this.demoDataMigrationService,
     this.demoDataInitializerService,
@@ -68,7 +70,8 @@ class App extends StatelessWidget {
        _navigatorKey = navigatorKey,
        _inlineAdCacheService = inlineAdCacheService,
        _initialRemoteConfig = initialRemoteConfig,
-       _initialRemoteConfigError = initialRemoteConfigError;
+       _initialRemoteConfigError = initialRemoteConfigError,
+       _packageInfoService = packageInfoService;
 
   final AuthRepository _authenticationRepository;
   final DataRepository<Headline> _headlinesRepository;
@@ -86,6 +89,7 @@ class App extends StatelessWidget {
   final DataRepository<LocalAd> _localAdRepository;
   final GlobalKey<NavigatorState> _navigatorKey;
   final InlineAdCacheService _inlineAdCacheService;
+  final PackageInfoService _packageInfoService;
   final DemoDataMigrationService? demoDataMigrationService;
   final DemoDataInitializerService? demoDataInitializerService;
   final User? initialUser;
@@ -114,6 +118,7 @@ class App extends StatelessWidget {
         RepositoryProvider.value(value: _adService),
         RepositoryProvider.value(value: _localAdRepository),
         RepositoryProvider.value(value: _inlineAdCacheService),
+        RepositoryProvider.value(value: _packageInfoService),
       ],
       child: MultiBlocProvider(
         providers: [
@@ -133,6 +138,7 @@ class App extends StatelessWidget {
               navigatorKey: _navigatorKey,
               initialRemoteConfig: _initialRemoteConfig,
               initialRemoteConfigError: _initialRemoteConfigError,
+              packageInfoService: _packageInfoService,
             )..add(AppStarted(initialUser: initialUser)),
           ),
           BlocProvider(
@@ -167,6 +173,7 @@ class App extends StatelessWidget {
           localAdRepository: _localAdRepository,
           navigatorKey: _navigatorKey,
           inlineAdCacheService: _inlineAdCacheService,
+          packageInfoService: _packageInfoService,
         ),
       ),
     );
@@ -189,6 +196,7 @@ class _AppView extends StatefulWidget {
     required this.localAdRepository,
     required this.navigatorKey,
     required this.inlineAdCacheService,
+    required this.packageInfoService,
   });
 
   final AuthRepository authenticationRepository;
@@ -205,6 +213,7 @@ class _AppView extends StatefulWidget {
   final DataRepository<LocalAd> localAdRepository;
   final GlobalKey<NavigatorState> navigatorKey;
   final InlineAdCacheService inlineAdCacheService;
+  final PackageInfoService packageInfoService;
 
   @override
   State<_AppView> createState() => _AppViewState();
@@ -402,7 +411,11 @@ class _AppViewState extends State<_AppView> {
               ],
               supportedLocales: AppLocalizations.supportedLocales,
               locale: state.locale,
-              home: const UpdateRequiredPage(),
+              home: UpdateRequiredPage(
+                iosUpdateUrl: state.remoteConfig!.appStatus.iosUpdateUrl,
+                androidUpdateUrl:
+                    state.remoteConfig!.appStatus.androidUpdateUrl,
+              ),
             );
           }
 

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -415,6 +415,8 @@ class _AppViewState extends State<_AppView> {
                 iosUpdateUrl: state.remoteConfig!.appStatus.iosUpdateUrl,
                 androidUpdateUrl:
                     state.remoteConfig!.appStatus.androidUpdateUrl,
+                currentAppVersion: state.currentAppVersion,
+                latestRequiredVersion: state.latestAppVersion,
               ),
             );
           }

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -25,6 +25,7 @@ import 'package:flutter_news_app_mobile_client_full_source_code/app/config/confi
     as app_config;
 import 'package:flutter_news_app_mobile_client_full_source_code/app/services/demo_data_initializer_service.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/app/services/demo_data_migration_service.dart';
+import 'package:flutter_news_app_mobile_client_full_source_code/app/services/package_info_service.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/bloc_observer.dart';
 import 'package:flutter_news_app_mobile_client_full_source_code/shared/data/clients/country_inmemory_client.dart';
 import 'package:http_client/http_client.dart';
@@ -190,6 +191,9 @@ Future<Widget> bootstrap(
   // Create a GlobalKey for the NavigatorState to be used by AppBloc
   // and InterstitialAdManager for BuildContext access.
   final navigatorKey = GlobalKey<NavigatorState>();
+
+  // Initialize PackageInfoService
+  final packageInfoService = PackageInfoServiceImpl(logger: logger);
 
   // 6. Initialize all other DataClients and Repositories.
   // These now also have a guaranteed valid httpClient.
@@ -453,5 +457,6 @@ Future<Widget> bootstrap(
     navigatorKey: navigatorKey,
     initialRemoteConfig: initialRemoteConfig,
     initialRemoteConfigError: initialRemoteConfigError,
+    packageInfoService: packageInfoService,
   );
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1705,6 +1705,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Suggested Sources'**
   String get suggestedSourcesTitle;
+
+  /// Message displayed in a snackbar when the update URL cannot be opened.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open update URL: {url}'**
+  String couldNotOpenUpdateUrl(String url);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1711,6 +1711,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not open update URL: {url}'**
   String couldNotOpenUpdateUrl(String url);
+
+  /// Label to display the current app version.
+  ///
+  /// In en, this message translates to:
+  /// **'Your current version: {version}'**
+  String currentAppVersionLabel(String version);
+
+  /// Label to display the latest required app version.
+  ///
+  /// In en, this message translates to:
+  /// **'Required version: {version}'**
+  String latestRequiredVersionLabel(String version);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -889,4 +889,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get suggestedSourcesTitle => 'مصادر مقترحة';
+
+  @override
+  String couldNotOpenUpdateUrl(String url) {
+    return 'تعذر فتح رابط التحديث: $url';
+  }
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -894,4 +894,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String couldNotOpenUpdateUrl(String url) {
     return 'تعذر فتح رابط التحديث: $url';
   }
+
+  @override
+  String currentAppVersionLabel(String version) {
+    return 'إصدارك الحالي: $version';
+  }
+
+  @override
+  String latestRequiredVersionLabel(String version) {
+    return 'الإصدار المطلوب: $version';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -891,4 +891,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get suggestedSourcesTitle => 'Suggested Sources';
+
+  @override
+  String couldNotOpenUpdateUrl(String url) {
+    return 'Could not open update URL: $url';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -896,4 +896,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String couldNotOpenUpdateUrl(String url) {
     return 'Could not open update URL: $url';
   }
+
+  @override
+  String currentAppVersionLabel(String version) {
+    return 'Your current version: $version';
+  }
+
+  @override
+  String latestRequiredVersionLabel(String version) {
+    return 'Required version: $version';
+  }
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1169,5 +1169,25 @@
                 "type": "String"
             }
         }
+    },
+    "currentAppVersionLabel": "إصدارك الحالي: {version}",
+    "@currentAppVersionLabel": {
+        "description": "تسمية لعرض إصدار التطبيق الحالي.",
+        "placeholders": {
+            "version": {
+                "type": "String",
+                "example": "1.0.0"
+            }
+        }
+    },
+    "latestRequiredVersionLabel": "الإصدار المطلوب: {version}",
+    "@latestRequiredVersionLabel": {
+        "description": "تسمية لعرض أحدث إصدار مطلوب للتطبيق.",
+        "placeholders": {
+            "version": {
+                "type": "String",
+                "example": "1.1.0"
+            }
+        }
     }
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1160,5 +1160,14 @@
     "suggestedSourcesTitle": "مصادر مقترحة",
     "@suggestedSourcesTitle": {
         "description": "عنوان لمجموعة المصادر المقترحة."
+    },
+    "couldNotOpenUpdateUrl": "تعذر فتح رابط التحديث: {url}",
+    "@couldNotOpenUpdateUrl": {
+        "description": "رسالة تظهر في شريط الإشعارات عندما يتعذر فتح رابط التحديث.",
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1169,5 +1169,25 @@
                 "type": "String"
             }
         }
+    },
+    "currentAppVersionLabel": "Your current version: {version}",
+    "@currentAppVersionLabel": {
+        "description": "Label to display the current app version.",
+        "placeholders": {
+            "version": {
+                "type": "String",
+                "example": "1.0.0"
+            }
+        }
+    },
+    "latestRequiredVersionLabel": "Required version: {version}",
+    "@latestRequiredVersionLabel": {
+        "description": "Label to display the latest required app version.",
+        "placeholders": {
+            "version": {
+                "type": "String",
+                "example": "1.1.0"
+            }
+        }
     }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1160,5 +1160,14 @@
     "suggestedSourcesTitle": "Suggested Sources",
     "@suggestedSourcesTitle": {
         "description": "Title for the suggested sources content collection."
+    },
+    "couldNotOpenUpdateUrl": "Could not open update URL: {url}",
+    "@couldNotOpenUpdateUrl": {
+        "description": "Message displayed in a snackbar when the update URL cannot be opened.",
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/status/view/update_required_page.dart
+++ b/lib/status/view/update_required_page.dart
@@ -1,87 +1,102 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_news_app_mobile_client_full_source_code/app/bloc/app_bloc.dart';
-import 'package:flutter_news_app_mobile_client_full_source_code/l10n/app_localizations.dart';
-import 'package:ui_kit/ui_kit.dart';
+import 'package:flutter_news_app_mobile_client_full_source_code/l10n/l10n.dart';
+import 'package:ui_kit/ui_kit.dart' hide UiKitL10n;
 import 'package:url_launcher/url_launcher.dart';
 
-/// A page displayed to the user when a mandatory app update is required.
+/// {@template update_required_page}
+/// A full-screen page displayed when a mandatory application update is required.
 ///
-/// This page informs the user that they must update the application to the
-/// latest version to continue using it. It provides a button that links
-/// directly to the appropriate app store page by fetching the URL from the
-/// remote configuration.
+/// This page informs the user about the need to update and provides links
+/// to the appropriate app stores (iOS, Android). On web, it displays a
+/// generic message as direct app store links are not applicable.
+/// {@endtemplate}
 class UpdateRequiredPage extends StatelessWidget {
   /// {@macro update_required_page}
-  const UpdateRequiredPage({super.key});
+  const UpdateRequiredPage({
+    required this.iosUpdateUrl,
+    required this.androidUpdateUrl,
+    super.key,
+  });
 
-  /// Attempts to launch the given URL in an external application (e.g., browser
-  /// or app store).
-  ///
-  /// Shows a [SnackBar] with an error message if the URL cannot be launched.
-  Future<void> _launchUrl(BuildContext context, String url) async {
-    // Ensure the URL is not empty before attempting to parse.
-    if (url.isEmpty) {
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          // TODO(fulleni): localize later.
-          const SnackBar(content: Text('Update URL is not available.')),
-        );
-      return;
-    }
+  /// The URL to open for iOS app updates.
+  final String iosUpdateUrl;
 
-    final uri = Uri.parse(url);
-    if (await canLaunchUrl(uri)) {
-      // Launch the URL externally. This will open the App Store, Play Store,
-      // or a browser.
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    } else {
-      // If the URL can't be launched, inform the user.
-      // ignore: use_build_context_synchronously
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          SnackBar(content: Text('Could not open update URL: $url')),
-        );
-    }
-  }
+  /// The URL to open for Android app updates.
+  final String androidUpdateUrl;
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-
-    // This is the robust, production-ready way to get the update URL.
-    // It uses BlocProvider.of(context) to access the AppBloc instance and
-    // determines the correct URL based on the current platform (iOS/Android).
-    // It falls back to an empty string if the remote config is not available.
-    final appBloc = BlocProvider.of<AppBloc>(context);
-    final updateUrl = Theme.of(context).platform == TargetPlatform.android
-        ? appBloc.state.remoteConfig?.appStatus.androidUpdateUrl
-        : appBloc.state.remoteConfig?.appStatus.iosUpdateUrl;
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
 
     return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            // Reusing the InitialStateWidget for a consistent UI.
-            InitialStateWidget(
-              icon: Icons.system_update_alt,
-              headline: l10n.updateRequiredHeadline,
-              subheadline: l10n.updateRequiredSubheadline,
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            // The button to direct the user to the app store.
-            // It's disabled if the update URL is not available.
-            ElevatedButton(
-              onPressed: updateUrl != null && updateUrl.isNotEmpty
-                  ? () => _launchUrl(context, updateUrl)
-                  : null,
-              child: Text(l10n.updateRequiredButton),
-            ),
-          ],
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.system_update_alt,
+                size: 80,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              Text(
+                l10n.updateRequiredHeadline,
+                style: theme.textTheme.headlineMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Text(
+                l10n.updateRequiredSubheadline,
+                style: theme.textTheme.bodyLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              if (!kIsWeb) ...[
+                // Show platform-specific update buttons for mobile
+                if (Theme.of(context).platform == TargetPlatform.iOS &&
+                    iosUpdateUrl.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: AppSpacing.md),
+                    child: ElevatedButton.icon(
+                      onPressed: () async {
+                        final url = Uri.parse(iosUpdateUrl);
+                        if (await canLaunchUrl(url)) {
+                          await launchUrl(url);
+                        }
+                      },
+                      icon: const Icon(Icons.apple),
+                      label: Text(l10n.updateRequiredButton),
+                    ),
+                  ),
+                if (Theme.of(context).platform == TargetPlatform.android &&
+                    androidUpdateUrl.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: AppSpacing.md),
+                    child: ElevatedButton.icon(
+                      onPressed: () async {
+                        final url = Uri.parse(androidUpdateUrl);
+                        if (await canLaunchUrl(url)) {
+                          await launchUrl(url);
+                        }
+                      },
+                      icon: const Icon(Icons.shop),
+                      label: Text(l10n.updateRequiredButton),
+                    ),
+                  ),
+              ] else ...[
+                // Generic message for web
+                Text(
+                  l10n.updateRequiredButton,
+                  style: theme.textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/status/view/update_required_page.dart
+++ b/lib/status/view/update_required_page.dart
@@ -64,8 +64,20 @@ class UpdateRequiredPage extends StatelessWidget {
                     child: ElevatedButton.icon(
                       onPressed: () async {
                         final url = Uri.parse(iosUpdateUrl);
-                        if (await canLaunchUrl(url)) {
-                          await launchUrl(url);
+                        if (!await launchUrl(
+                          url,
+                          mode: LaunchMode.externalApplication,
+                        )) {
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context)
+                            ..hideCurrentSnackBar()
+                            ..showSnackBar(
+                              SnackBar(
+                                content: Text(
+                                  l10n.couldNotOpenUpdateUrl(iosUpdateUrl),
+                                ),
+                              ),
+                            );
                         }
                       },
                       icon: const Icon(Icons.apple),
@@ -79,8 +91,20 @@ class UpdateRequiredPage extends StatelessWidget {
                     child: ElevatedButton.icon(
                       onPressed: () async {
                         final url = Uri.parse(androidUpdateUrl);
-                        if (await canLaunchUrl(url)) {
-                          await launchUrl(url);
+                        if (!await launchUrl(
+                          url,
+                          mode: LaunchMode.externalApplication,
+                        )) {
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context)
+                            ..hideCurrentSnackBar()
+                            ..showSnackBar(
+                              SnackBar(
+                                content: Text(
+                                  l10n.couldNotOpenUpdateUrl(androidUpdateUrl),
+                                ),
+                              ),
+                            );
                         }
                       },
                       icon: const Icon(Icons.shop),

--- a/lib/status/view/update_required_page.dart
+++ b/lib/status/view/update_required_page.dart
@@ -16,6 +16,8 @@ class UpdateRequiredPage extends StatelessWidget {
   const UpdateRequiredPage({
     required this.iosUpdateUrl,
     required this.androidUpdateUrl,
+    required this.currentAppVersion,
+    required this.latestRequiredVersion,
     super.key,
   });
 
@@ -24,6 +26,12 @@ class UpdateRequiredPage extends StatelessWidget {
 
   /// The URL to open for Android app updates.
   final String androidUpdateUrl;
+
+  /// The current version of the application.
+  final String? currentAppVersion;
+
+  /// The latest required version of the application.
+  final String? latestRequiredVersion;
 
   @override
   Widget build(BuildContext context) {
@@ -54,6 +62,19 @@ class UpdateRequiredPage extends StatelessWidget {
                 style: theme.textTheme.bodyLarge,
                 textAlign: TextAlign.center,
               ),
+              if (currentAppVersion != null && latestRequiredVersion != null) ...[
+                const SizedBox(height: AppSpacing.md),
+                Text(
+                  l10n.currentAppVersionLabel(currentAppVersion!),
+                  style: theme.textTheme.bodySmall,
+                  textAlign: TextAlign.center,
+                ),
+                Text(
+                  l10n.latestRequiredVersionLabel(latestRequiredVersion!),
+                  style: theme.textTheme.bodySmall,
+                  textAlign: TextAlign.center,
+                ),
+              ],
               const SizedBox(height: AppSpacing.xl),
               if (!kIsWeb) ...[
                 // Show platform-specific update buttons for mobile

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -649,6 +649,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -762,7 +778,7 @@ packages:
     source: hosted
     version: "6.1.5+1"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,9 @@ dependencies:
       ref: 4cefd202c5fc0c53856782fea7760baa1d0733f7
   logging: ^1.3.0
   meta: ^1.16.0
+  package_info_plus: ^9.0.0
   pinput: ^5.0.1
+  pub_semver: ^2.2.0
   share_plus: ^11.0.0
   stream_transform: ^2.1.1
   timeago: ^3.7.1


### PR DESCRIPTION
## Status

**READY**

## Description

This pull request introduces a critical new feature for app version enforcement. It leverages remote configuration to determine if a user's app version is outdated and requires an update. If an update is necessary, the application will direct the user to a new dedicated page, providing clear instructions and links to the relevant app store. This ensures a consistent user experience and that all users are running on supported application versions.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore