### PR TITLE
Fix/use push named for auth flow to preserve navigation stack

### DIFF
--- a/lib/authentication/view/account_linking_page.dart
+++ b/lib/authentication/view/account_linking_page.dart
@@ -75,7 +75,7 @@ class AccountLinkingPage extends StatelessWidget {
                       onPressed: isLoading
                           ? null
                           : () {
-                              context.goNamed(
+                              context.pushNamed(
                                 Routes.accountLinkingRequestCodeName,
                               );
                             },

--- a/lib/authentication/view/authentication_page.dart
+++ b/lib/authentication/view/authentication_page.dart
@@ -85,7 +85,7 @@ class AuthenticationPage extends StatelessWidget {
                         onPressed: isLoading
                             ? null
                             : () {
-                                context.goNamed(Routes.requestCodeName);
+                                context.pushNamed(Routes.requestCodeName);
                               },
                         label: Text(l10n.authenticationEmailSignInButton),
                         style: ElevatedButton.styleFrom(

--- a/lib/authentication/view/request_code_page.dart
+++ b/lib/authentication/view/request_code_page.dart
@@ -72,12 +72,12 @@ class _RequestCodeView extends StatelessWidget {
                 context,
               ).routerDelegate.currentConfiguration.last.route.name;
               if (currentRouteName == Routes.accountLinkingRequestCodeName) {
-                context.goNamed(
+                context.pushNamed(
                   Routes.accountLinkingVerifyCodeName,
                   pathParameters: {'email': state.email!},
                 );
               } else {
-                context.goNamed(
+                context.pushNamed(
                   Routes.verifyCodeName,
                   pathParameters: {'email': state.email!},
                 );


### PR DESCRIPTION
## Status

**READY**

## Description

This pull request implements a crucial bug fix within the application's authentication flow. The core change involves updating navigation calls from goNamed to pushNamed across key authentication screens. This modification ensures that the navigation stack is properly preserved, allowing users to utilize the back button and navigate through the authentication process as expected, thereby enhancing the user experience.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore